### PR TITLE
Refactor sensor demo configuration and update CMake logic

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -18,7 +18,6 @@ target_sources(app PRIVATE src/main.c
     src/modules/modem/modem_service.c
     src/modules/ntn/ntn_service.c
     src/modules/rsrp/rsrp_service.c
-    src/modules/sensors/accel.c
 )
 
 
@@ -33,6 +32,10 @@ target_include_directories(app PRIVATE
     src/modules/sensors
 )
 
-target_sources(app PRIVATE
-    src/modules/sensors/batt.c
-)
+if(CONFIG_APP_SENSOR_ACCEL_DEMO)
+    target_sources(app PRIVATE src/modules/sensors/accel.c)
+endif()
+
+if(CONFIG_APP_SENSOR_BATT_DEMO)
+    target_sources(app PRIVATE src/modules/sensors/batt.c)
+endif()

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -56,6 +56,22 @@ config APP_MODEM_RSRP_DROP_DB
       Minimum drop in dB used by the modem service when deciding that the
       LTE-M signal is degrading toward an NTN fallback.
 
+config APP_SENSOR_ACCEL_DEMO
+    bool "Enable accelerometer demo"
+    default y if BOARD_THINGY91X_NRF9151_NS
+    default n
+    help
+      Build the BMI270 accelerometer demo and motion-hint generation.
+      Enable this on boards that actually provide a compatible accelerometer.
+
+config APP_SENSOR_BATT_DEMO
+    bool "Enable battery demo"
+    default y if BOARD_THINGY91X_NRF9151_NS
+    default n
+    help
+      Build the nPM1300 battery/charger demo.
+      Enable this on boards that actually provide compatible battery hardware.
+
 config APP_CORE_SEND_UDP_DATA
     bool "Send UDP data over NTN"
     help

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -22,7 +22,9 @@
 #include "app_types.h"
 #include "app_events.h"
 #include "app_sm.h"
+#if defined(CONFIG_APP_SENSOR_ACCEL_DEMO)
 #include "accel.h"
+#endif
 
 
 LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
@@ -42,8 +44,9 @@ int main(void)
 
     LOG_INF("Firmware version: %s", APP_VERSION_STRING);
 
+#if defined(CONFIG_APP_SENSOR_ACCEL_DEMO)
     accel_start();
-    
+#endif
 
     while (1) {
         k_sleep(K_SECONDS(60));


### PR DESCRIPTION
This pull request introduces conditional compilation for the accelerometer and battery sensor demo modules, making their inclusion in the build configurable via new Kconfig options. This allows the firmware to only include sensor demos relevant to the target hardware, improving build flexibility and reducing unnecessary code on unsupported boards.

**Build system improvements:**

* Added two new Kconfig options, `CONFIG_APP_SENSOR_ACCEL_DEMO` and `CONFIG_APP_SENSOR_BATT_DEMO`, to enable or disable the accelerometer and battery demo modules respectively. These default to enabled for the `BOARD_THINGY91X_NRF9151_NS` board and disabled otherwise.
* Updated `app/CMakeLists.txt` to conditionally include `accel.c` and `batt.c` source files based on the new Kconfig options, instead of always including them. [[1]](diffhunk://#diff-fd99ceeacdfe207bd1168e1c30c94ed9f316895e74154c83258807c703288b3fL21) [[2]](diffhunk://#diff-fd99ceeacdfe207bd1168e1c30c94ed9f316895e74154c83258807c703288b3fL36-R41)

**Source code changes:**

* Wrapped the inclusion and initialization of the accelerometer demo (`accel.h` and `accel_start()`) in `main.c` with `#if defined(CONFIG_APP_SENSOR_ACCEL_DEMO)`, ensuring it is only used when enabled. [[1]](diffhunk://#diff-18a06207913cad40c22ab9a9f6540cab69abbcdd85cd891a928b6b2aba7cb3c1R25-R27) [[2]](diffhunk://#diff-18a06207913cad40c22ab9a9f6540cab69abbcdd85cd891a928b6b2aba7cb3c1R47-R49)…n files